### PR TITLE
Refactor otb

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,9 +13,10 @@ import { PrismaExceptionFilter } from './http-exeption.filter';
 import { SessionModule } from './session/session.module';
 import { SmtpModule } from './smtp/smtp.module';
 import { AuthGuard } from './auth/auth.guard';
+import { SharedUserModule } from './shared-user/shared-user.module';
 
 @Module({
-  imports: [PrismaModule, UserModule, PostModule, OtbModule, AuthModule, SessionModule, SmtpModule],
+  imports: [PrismaModule, UserModule, PostModule, OtbModule, AuthModule, SessionModule, SmtpModule, SharedUserModule],
   controllers: [AppController],
   providers: [{
     provide: APP_GUARD,

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -3,9 +3,6 @@ import {
   Get,
   Post,
   Body,
-  Patch,
-  Param,
-  Request,
   HttpCode,
   HttpStatus,
   UseGuards,
@@ -15,11 +12,13 @@ import { AuthGuard } from './auth.guard';
 import { SignInDto } from './dto/signInDto';
 import { CurrentUser } from './decorators/current-user.decorator';
 import { JwtPayload } from './dto/jwt-payload.dto';
+import { Public } from './decorators/public.decorator';
 
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
+  @Public()
   @HttpCode(HttpStatus.OK)
   @Post('login')
   signIn(@Body() signInDto: SignInDto) {

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -25,7 +25,6 @@ export class AuthController {
     return this.authService.signIn(signInDto);
   }
 
-  @UseGuards(AuthGuard)
   @Get('profile')
   getProfile(@CurrentUser() user:JwtPayload) {
     return user

--- a/src/auth/auth.guard.ts
+++ b/src/auth/auth.guard.ts
@@ -4,18 +4,28 @@ import {
   Injectable,
   UnauthorizedException,
 } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { JwtService } from '@nestjs/jwt';
 import { Request } from 'express';
 import { SessionService } from 'src/session/session.service';
+import { IS_PUBLIC_KEY } from './decorators/public.decorator';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
   constructor(
     private jwtService: JwtService,
     private sessionService: SessionService,
+    private readonly reflector: Reflector
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(
+      IS_PUBLIC_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+    if (isPublic) {
+      return true;
+    }
     const request = context.switchToHttp().getRequest();
     const token = this.extractTokenFromHeader(request);
     if (!token) {

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -5,11 +5,12 @@ import { UserModule } from 'src/user/user.module';
 import { JwtModule } from '@nestjs/jwt';
 import { SessionModule } from 'src/session/session.module';
 import { AuthGuard } from './auth.guard';
+import { SmtpModule } from 'src/smtp/smtp.module';
 
 @Module({
   imports: [
+    SmtpModule,
     SessionModule,
-    UserModule,
     JwtModule.register({
       global: true,
       secret: process.env.KEY,

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,15 +1,14 @@
 import { Module } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
-import { UserModule } from 'src/user/user.module';
 import { JwtModule } from '@nestjs/jwt';
 import { SessionModule } from 'src/session/session.module';
 import { AuthGuard } from './auth.guard';
-import { SmtpModule } from 'src/smtp/smtp.module';
+import { SharedUserModule } from 'src/shared-user/shared-user.module';
 
 @Module({
   imports: [
-    SmtpModule,
+    SharedUserModule,
     SessionModule,
     JwtModule.register({
       global: true,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -8,17 +8,19 @@ import { randomUUID } from 'crypto';
 import { generateJWT } from './utils/authUtils';
 import { SessionService } from 'src/session/session.service';
 import { CreateSessionDto } from 'src/session/dto/create-session.dto';
+import { SmtpService } from 'src/smtp/smtp.service';
 const bcrypt = require('bcrypt');
 
 @Injectable()
 export class AuthService {
   constructor(
     private jwtService: JwtService,
-    private readonly userService: UserService,
+    
+    private readonly smtpService: SmtpService,
     private readonly sessionService: SessionService,
   ) {}
   async signIn(signInDto: SignInDto): Promise<{ access_token: string }> {
-    const user = await this.userService.findUserByEmail(signInDto.email);
+    const user = await this.smtpService.findUserByEmail(signInDto.email);
     if (!user) {
       throw new UnauthorizedException('Invalid credentials');
     }

--- a/src/auth/decorators/public.decorator.ts
+++ b/src/auth/decorators/public.decorator.ts
@@ -1,0 +1,5 @@
+// public.decorator.ts
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'isPublic';
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/src/auth/decorators/public.decorator.ts
+++ b/src/auth/decorators/public.decorator.ts
@@ -1,4 +1,3 @@
-// public.decorator.ts
 import { SetMetadata } from '@nestjs/common';
 
 export const IS_PUBLIC_KEY = 'isPublic';

--- a/src/otb/dto/verify-otb.dto.ts
+++ b/src/otb/dto/verify-otb.dto.ts
@@ -1,0 +1,12 @@
+import { IsEmail, IsNotEmpty, IsString } from "class-validator";
+
+export class VerifyOtbDto {
+    @IsString({ message: 'The email must be a string' })
+    @IsNotEmpty({ message: 'The email cannot be empty' })
+    @IsEmail({}, { message: 'Invalid email format' })
+    email: string;
+    
+    @IsString({ message: 'The token must be a string' })
+    @IsNotEmpty({ message: 'The token cannot be empty' })
+    token: string;
+}

--- a/src/otb/otb.controller.ts
+++ b/src/otb/otb.controller.ts
@@ -2,6 +2,8 @@ import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/commo
 import { OtbService } from './otb.service';
 import { CreateOtbDto } from './dto/create-otb.dto';
 import { UpdateOtbDto } from './dto/update-otb.dto';
+import { VerifyOtbDto } from './dto/verify-otb.dto';
+import { Public } from 'src/auth/decorators/public.decorator';
 
 @Controller('otb')
 export class OtbController {
@@ -16,12 +18,10 @@ export class OtbController {
   findAll() {
     return this.otbService.findAll();
   }
-
   @Get(':id')
   findOne(@Param('id') id: string) {
     return this.otbService.findOne(+id);
   }
-
   @Patch(':id')
   update(@Param('id') id: string, @Body() updateOtbDto: UpdateOtbDto) {
     return this.otbService.update(+id, updateOtbDto);
@@ -30,5 +30,10 @@ export class OtbController {
   @Delete(':id')
   remove(@Param('id') id: string) {
     return this.otbService.remove(+id);
+  }
+  @Public()
+  @Post("verify")
+  verify(@Body() verifyOtbDto:VerifyOtbDto) {
+    return this.otbService.findOtbByUserEmail(verifyOtbDto);
   }
 }

--- a/src/otb/otb.module.ts
+++ b/src/otb/otb.module.ts
@@ -2,10 +2,10 @@ import { Module } from '@nestjs/common';
 import { OtbService } from './otb.service';
 import { OtbController } from './otb.controller';
 import { PrismaModule } from 'src/prisma/prisma.module';
-import { SmtpModule } from 'src/smtp/smtp.module';
+import { SharedUserModule } from 'src/shared-user/shared-user.module';
 
 @Module({
-  imports: [PrismaModule,SmtpModule],
+  imports: [PrismaModule,SharedUserModule],
   controllers: [OtbController],
   providers: [OtbService],
   exports: [OtbService],

--- a/src/otb/otb.module.ts
+++ b/src/otb/otb.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { OtbService } from './otb.service';
 import { OtbController } from './otb.controller';
 import { PrismaModule } from 'src/prisma/prisma.module';
+import { SmtpModule } from 'src/smtp/smtp.module';
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule,SmtpModule],
   controllers: [OtbController],
   providers: [OtbService],
   exports: [OtbService],

--- a/src/otb/otb.service.ts
+++ b/src/otb/otb.service.ts
@@ -2,10 +2,13 @@ import { Injectable } from '@nestjs/common';
 import { CreateOtbDto } from './dto/create-otb.dto';
 import { UpdateOtbDto } from './dto/update-otb.dto';
 import { PrismaService } from 'src/prisma/prisma.service';
+import { VerifyOtbDto } from './dto/verify-otb.dto';
+import { UserService } from 'src/user/user.service';
+import { SmtpService } from 'src/smtp/smtp.service';
 
 @Injectable()
 export class OtbService {
-  constructor(private readonly dbClient: PrismaService) {}
+  constructor(private readonly dbClient: PrismaService, private readonly smtpService:SmtpService) {}
   create(createOtbDto: CreateOtbDto) {
     return this.dbClient.otb.create({
       data: {
@@ -13,6 +16,23 @@ export class OtbService {
       }})
   }
 
+  async findOtbByUserEmail(verifyOtbDto:VerifyOtbDto) {
+    const user= await this.smtpService.findUserByEmail(verifyOtbDto.email);
+    if(!user) throw new Error("User not found");
+    const t= await this.dbClient.otb.findFirst({
+      where: {
+        userId:user.id,
+        token:+verifyOtbDto.token
+      }
+    });
+    if(!t) {throw new Error("Token OTP not found")};
+    await this.dbClient.otb.delete({
+      where: {
+        id:t.id
+      }
+    });
+    return "Token OTP verified successfully";
+  }
   findAll() {
     return `This action returns all otb`;
   }

--- a/src/otb/otb.service.ts
+++ b/src/otb/otb.service.ts
@@ -5,10 +5,11 @@ import { PrismaService } from 'src/prisma/prisma.service';
 import { VerifyOtbDto } from './dto/verify-otb.dto';
 import { UserService } from 'src/user/user.service';
 import { SmtpService } from 'src/smtp/smtp.service';
+import { SharedUserService } from 'src/shared-user/shared-user.service';
 
 @Injectable()
 export class OtbService {
-  constructor(private readonly dbClient: PrismaService, private readonly smtpService:SmtpService) {}
+  constructor(private readonly dbClient: PrismaService, private readonly sharedUserService:SharedUserService) {}
   create(createOtbDto: CreateOtbDto) {
     return this.dbClient.otb.create({
       data: {
@@ -17,8 +18,9 @@ export class OtbService {
   }
 
   async findOtbByUserEmail(verifyOtbDto:VerifyOtbDto) {
-    const user= await this.smtpService.findUserByEmail(verifyOtbDto.email);
+    const user= await this.sharedUserService.findUserByEmail(verifyOtbDto.email);
     if(!user) throw new Error("User not found");
+    if(user.state) throw new Error("User already verified");
     const t= await this.dbClient.otb.findFirst({
       where: {
         userId:user.id,
@@ -26,6 +28,7 @@ export class OtbService {
       }
     });
     if(!t) {throw new Error("Token OTP not found")};
+    await this.sharedUserService.updateUserState(user.id);
     await this.dbClient.otb.delete({
       where: {
         id:t.id

--- a/src/post/post.controller.ts
+++ b/src/post/post.controller.ts
@@ -14,10 +14,7 @@ import { CreatePostDto } from './dto/create-post.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
 import { CurrentUser } from 'src/auth/decorators/current-user.decorator';
 import { JwtPayload } from 'src/auth/dto/jwt-payload.dto';
-import { AuthGuard } from 'src/auth/auth.guard';
 import { PaginationPostDto } from './dto/pagination-post.dto';
-
-@UseGuards(AuthGuard)
 @Controller('post')
 export class PostController {
   constructor(private readonly postService: PostService) {}

--- a/src/shared-user/shared-user.module.ts
+++ b/src/shared-user/shared-user.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { SharedUserService } from './shared-user.service';
+import { PrismaModule } from 'src/prisma/prisma.module';
+
+@Module({
+  providers: [SharedUserService],
+  imports: [PrismaModule],
+  exports: [SharedUserService],
+})
+export class SharedUserModule {
+
+
+}

--- a/src/shared-user/shared-user.service.ts
+++ b/src/shared-user/shared-user.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { UserService } from 'src/user/user.service';
+
+@Injectable()
+export class SharedUserService {
+    constructor( private readonly dbClient:PrismaService) {
+    }
+    async findUserByEmail(email: string) {
+        return this.dbClient.user.findUnique({
+          where:{
+            email
+          }
+        })
+      }
+      async updateUserState(id: string) {
+        return this.dbClient.user.update({
+          where: {
+            id,
+          },
+          data: {
+            state:true,
+          },
+        });
+      }
+}

--- a/src/smtp/smtp.module.ts
+++ b/src/smtp/smtp.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { SmtpService } from './smtp.service';
+import { PrismaModule } from 'src/prisma/prisma.module';
 
 @Module({
   providers: [SmtpService],
   exports: [SmtpService],
+  imports: [PrismaModule],
 })
 export class SmtpModule {}

--- a/src/smtp/smtp.service.ts
+++ b/src/smtp/smtp.service.ts
@@ -1,11 +1,20 @@
 import { Injectable } from '@nestjs/common';
 import { SendEmailDto } from './dto/send-email.dto';
 import { transporter } from './config/config.smtp';
+import { PrismaService } from 'src/prisma/prisma.service';
 
 
 
 @Injectable()
 export class SmtpService {
+  constructor(private readonly dbClient: PrismaService) {}
+  async findUserByEmail(email: string) {
+    return this.dbClient.user.findUnique({
+      where:{
+        email
+      }
+    })
+  }
     async  sendEmail(sendEmailDto:SendEmailDto) {
         
         const info = await transporter.sendMail({

--- a/src/smtp/smtp.service.ts
+++ b/src/smtp/smtp.service.ts
@@ -8,13 +8,7 @@ import { PrismaService } from 'src/prisma/prisma.service';
 @Injectable()
 export class SmtpService {
   constructor(private readonly dbClient: PrismaService) {}
-  async findUserByEmail(email: string) {
-    return this.dbClient.user.findUnique({
-      where:{
-        email
-      }
-    })
-  }
+  
     async  sendEmail(sendEmailDto:SendEmailDto) {
         
         const info = await transporter.sendMail({

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,18 +1,16 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Delete } from '@nestjs/common';
 import { UserService } from './user.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { CurrentUser } from 'src/auth/decorators/current-user.decorator';
-import { J } from '@faker-js/faker/dist/airline-CBNP41sR';
-import { JwkKeyExportOptions } from 'crypto';
 import { JwtPayload } from 'src/auth/dto/jwt-payload.dto';
 import { UpdateUserPasswordDto } from './dto/update-user-password';
-import { AuthGuard } from 'src/auth/auth.guard';
+import { Public } from 'src/auth/decorators/public.decorator';
 
 @Controller('user')
 export class UserController {
   constructor(private readonly userService: UserService) {}
-
+  @Public()
   @Post("create-account")
   create(@Body() createUserDto: CreateUserDto) {
     return this.userService.create(createUserDto);
@@ -23,24 +21,20 @@ export class UserController {
     return this.userService.findAll();
   }
 
-  @UseGuards(AuthGuard)
   @Get()
   findOne(@CurrentUser() user:JwtPayload) {
     return this.userService.findOne(user.userId);
   }
 
-  @UseGuards(AuthGuard)
   @Patch("/edit")
   update( @CurrentUser() user:JwtPayload, @Body() updateUserDto: UpdateUserDto) {
     return this.userService.update(user.userId, updateUserDto);
   }
 
-  @UseGuards(AuthGuard)
   @Delete()
   remove(@CurrentUser() user:JwtPayload) {
     return this.userService.remove(user.userId);
   }
-  @UseGuards(AuthGuard)
   @Patch('updatePassword')
   updatePassword(@CurrentUser() user:JwtPayload,@Body() updateUserPasswordDto: UpdateUserPasswordDto) {
     return this.userService.updatePassword(user,updateUserPasswordDto);

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -15,13 +15,7 @@ export class UserService {
     private readonly otbService:OtbService, 
     private readonly smtService:SmtpService,
     private readonly sessionService:SessionService) {}
-  findUserByEmail(email: string) {
-    return this.dbClient.user.findUnique({
-      where:{
-        email
-      }
-    })
-  }
+  
   async create(createUserDto: CreateUserDto) {
     const birthDate= new Date(createUserDto.birthDate);
     const encryptedPassword = await bcrypt.hash(createUserDto.password, 10);

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -25,7 +25,7 @@ export class UserService {
         lastName: createUserDto.lastName,
         email: createUserDto.email,
         password: encryptedPassword,
-        state: true,
+        state: false,
         birthDate,
       }
     });


### PR DESCRIPTION
Para usar el otb se creo un modulo shared-user para poder compartir funciones de user sin generar redundancia entre user y otb, 
a parte se creo un decorador public dado que mover el authGuard al app.module se protegieron todas las rutas y habia que establecer rutas publicas, con el decorador se valida en el middleware para verificar si es una ruta publica y se evita redundancia de modulos con auth y otros